### PR TITLE
Fixed example to show return code

### DIFF
--- a/app/resources/katas/reversor/description.md
+++ b/app/resources/katas/reversor/description.md
@@ -18,7 +18,7 @@ $ reversor bar foo
 oof rab
 $ reversor hello™
 ™olleh
-$ reversor && echo $?
+$ reversor || echo $?
 Please provide at least one argument to reverse
 1
 ```


### PR DESCRIPTION
Given was '&&' which required the reversor to succes, which is not the
requirement in the example.
